### PR TITLE
Removed final keyword from layers classes

### DIFF
--- a/Viperit Module.xctemplate/Universal/___FILEBASENAME___DisplayData.swift
+++ b/Viperit Module.xctemplate/Universal/___FILEBASENAME___DisplayData.swift
@@ -9,6 +9,6 @@
 import Foundation
 import Viperit
 
-final class ___FILEBASENAMEASIDENTIFIER___DisplayData: DisplayData {
+class ___FILEBASENAMEASIDENTIFIER___DisplayData: DisplayData {
 
 }

--- a/Viperit Module.xctemplate/Universal/___FILEBASENAME___Interactor.swift
+++ b/Viperit Module.xctemplate/Universal/___FILEBASENAME___Interactor.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Viperit
 
-final class ___FILEBASENAMEASIDENTIFIER___Interactor: Interactor {
+class ___FILEBASENAMEASIDENTIFIER___Interactor: Interactor {
 }
 
 // MARK: - VIPER COMPONENTS API (Auto-generated code)

--- a/Viperit Module.xctemplate/Universal/___FILEBASENAME___Presenter.swift
+++ b/Viperit Module.xctemplate/Universal/___FILEBASENAME___Presenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Viperit
 
-final class ___FILEBASENAMEASIDENTIFIER___Presenter: Presenter {
+class ___FILEBASENAMEASIDENTIFIER___Presenter: Presenter {
 }
 
 

--- a/Viperit Module.xctemplate/Universal/___FILEBASENAME___Router.swift
+++ b/Viperit Module.xctemplate/Universal/___FILEBASENAME___Router.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Viperit
 
-final class ___FILEBASENAMEASIDENTIFIER___Router: Router {
+class ___FILEBASENAMEASIDENTIFIER___Router: Router {
 }
 
 // MARK: - VIPER COMPONENTS API (Auto-generated code)


### PR DESCRIPTION
Hi, i'm removed **final** keyword from layers classes.
It's make life better for Mocking.

For example:
We use Cuckoo framework for mocking and it use inherence for test mock and base implementation if needed. With **final** it's impossible, but with protocol-orientated it's better, but have some overhead.